### PR TITLE
JAT-22 Enable/Disable equalizer settings

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,4 +1,5 @@
 export enum ErrorCode {
+  PEACE_UNKNOWN_ERROR = 0,
   PEACE_NOT_INSTALLED = 1,
   PEACE_NOT_RUNNING = 2,
   PEACE_NOT_READY = 3,
@@ -12,6 +13,11 @@ export type ErrorDescription = {
 };
 
 export const errors: Record<ErrorCode, ErrorDescription> = {
+  [ErrorCode.PEACE_UNKNOWN_ERROR]: {
+    shortError: 'Unknown error occured with Peace.',
+    action: 'Please restart PeaceGUI and try again.',
+    code: ErrorCode.PEACE_UNKNOWN_ERROR,
+  },
   [ErrorCode.PEACE_NOT_INSTALLED]: {
     shortError: 'Peace not installed.',
     action:

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -1,6 +1,6 @@
 import { app, ipcRenderer, IpcRendererEvent } from 'electron';
 
-export type Channels = 'peace';
+export type Channels = string;
 
 const sendMessage = (channel: Channels, args: unknown[]) => {
   ipcRenderer.send(channel, args);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 import './App.css';
 import { getProgramState } from './equalizerApi';
+import EqualizerEnablerSwitch from './EqualizerEnablerSwitch';
 import { PeaceFoundContext } from './PeaceFoundContext';
 import PrereqMissingModal from './PrereqMissingModal';
 import Slider from './Slider';
@@ -10,6 +11,7 @@ import Slider from './Slider';
 const AppContent = () => {
   return (
     <div className="row">
+      <EqualizerEnablerSwitch id="equalizerEnabler" />
       <Slider />
     </div>
   );

--- a/src/renderer/EqualizerEnablerSwitch.tsx
+++ b/src/renderer/EqualizerEnablerSwitch.tsx
@@ -1,0 +1,50 @@
+import { ErrorDescription } from 'common/errors';
+import { useCallback, useContext, useState } from 'react';
+import {
+  disableEqualizer,
+  enableEqualizer,
+  getEqualizerStatus,
+} from './equalizerApi';
+import { PeaceFoundContext } from './PeaceFoundContext';
+import Switch from './Switch';
+
+interface IEqualizerEnablerSwitchProps {
+  id: string;
+}
+
+export default function EqualizerEnablerSwitch({
+  id,
+}: IEqualizerEnablerSwitchProps) {
+  const { setPeaceError } = useContext(PeaceFoundContext);
+  const [equalizerEnabled, setEqualizerEnabled] = useState<boolean>(false);
+
+  const equalizerEnablerOnLoad = useCallback(async () => {
+    try {
+      setEqualizerEnabled(await getEqualizerStatus());
+    } catch (e) {
+      setPeaceError(e as ErrorDescription);
+    }
+  }, [setPeaceError]);
+
+  const handleToggleEqualizer = useCallback(async () => {
+    try {
+      if (equalizerEnabled) {
+        await disableEqualizer();
+      } else {
+        await enableEqualizer();
+      }
+      setEqualizerEnabled(!equalizerEnabled);
+    } catch (e) {
+      setPeaceError(e as ErrorDescription);
+    }
+  }, [equalizerEnabled, setPeaceError]);
+
+  return (
+    <Switch
+      isOn={equalizerEnabled}
+      handleToggle={handleToggleEqualizer}
+      id={id}
+      onLoad={equalizerEnablerOnLoad}
+    />
+  );
+}

--- a/src/renderer/Slider.tsx
+++ b/src/renderer/Slider.tsx
@@ -30,7 +30,6 @@ export default function Slider() {
     const fetchResults = async () => {
       try {
         const initGain = await getMainPreAmp();
-        console.log('result from getMainPreAmp', initGain);
         setPreAmpGain(initGain);
         setInputGain(initGain);
       } catch (e) {
@@ -48,8 +47,7 @@ export default function Slider() {
     setPreAmpGain(newValue);
     setInputGain(newValue);
     try {
-      const res = await setMainPreAmp(newValue);
-      console.log('result from setMainPreAmp', res);
+      await setMainPreAmp(newValue);
     } catch (e) {
       setPeaceError(e as ErrorDescription);
     }

--- a/src/renderer/Switch.css
+++ b/src/renderer/Switch.css
@@ -1,0 +1,40 @@
+.react-switch-checkbox {
+  height: 0;
+  width: 0;
+  visibility: hidden;
+}
+
+.react-switch-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  width: 100px;
+  height: 50px;
+  background: grey;
+  border-radius: 100px;
+  position: relative;
+  transition: background-color 0.2s;
+}
+
+.react-switch-label .react-switch-button {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 45px;
+  height: 45px;
+  border-radius: 45px;
+  transition: 0.2s;
+  background: #fff;
+  box-shadow: 0 0 2px 0 rgba(10, 10, 10, 0.29);
+}
+
+.react-switch-checkbox:checked + .react-switch-label .react-switch-button {
+  left: calc(100% - 2px);
+  transform: translateX(-100%);
+}
+
+.react-switch-label:active .react-switch-button {
+  width: 60px;
+}

--- a/src/renderer/Switch.tsx
+++ b/src/renderer/Switch.tsx
@@ -1,0 +1,46 @@
+import './Switch.css';
+import { useEffect, useContext, ChangeEventHandler } from 'react';
+import { PeaceFoundContext } from './PeaceFoundContext';
+
+interface ISwitchProps {
+  isOn: boolean | undefined;
+  handleToggle: ChangeEventHandler<HTMLInputElement>;
+  id: string;
+  onLoad: () => void;
+}
+
+// Taken from https://upmostly.com/tutorials/build-a-react-switch-toggle-component
+export default function Switch({
+  isOn,
+  handleToggle,
+  id,
+  onLoad,
+}: ISwitchProps) {
+  const { peaceError } = useContext(PeaceFoundContext);
+  useEffect(() => {
+    console.log(`peaceError ${peaceError}`);
+    if (!peaceError) {
+      onLoad();
+    }
+  }, [onLoad, peaceError]);
+
+  return (
+    <>
+      <input
+        checked={isOn}
+        onChange={handleToggle}
+        className="react-switch-checkbox"
+        id={id}
+        type="checkbox"
+      />
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label
+        style={{ background: isOn ? '#06D6A0' : '' }}
+        className="react-switch-label"
+        htmlFor={id}
+      >
+        <span className="react-switch-button" />
+      </label>
+    </>
+  );
+}

--- a/src/renderer/Switch.tsx
+++ b/src/renderer/Switch.tsx
@@ -18,7 +18,6 @@ export default function Switch({
 }: ISwitchProps) {
   const { peaceError } = useContext(PeaceFoundContext);
   useEffect(() => {
-    console.log(`peaceError ${peaceError}`);
     if (!peaceError) {
       onLoad();
     }


### PR DESCRIPTION
Estimate: 5 hours

Goal: User should be able to enable and disable the effects applied by the equalizer on their audio.

Typical Scenario:

```
[User] 1. User sees some element on AQUA interface that indicates the equalizer is enabled / disabled
[User] 2. User presses a button to toggle equalizer status
[AQUA] 3. Sends signal to Peace to enable / disable equalizer
[Peac] 4. Sends ACK to AQUA indicating change has been made
[AQUA] 5. Indicates to user that equalizer status was toggled
[User] 6. User can hear whether the equalized settings have been turned on/off
```
Alternatives: None

Exceptions:

1. At any time if Peace stops running, go to Exception 3 of [JAT-52](https://linear.app/jaty/issue/JAT-52/handling-unlaunched-peace-exception-case) 

Success Metrics:

- Users are at all times, able to enable or disable their equalizer settings.

Assumptions:

- Some functionality that can apply an effect to a user's audio exists and can be used for testing this feature

Estimation Cases:

- (+2hr) backend API might require "undoing" all effects so all existing features need to be handled accordingly