### PR TITLE
JAT-58 Fix Quitting

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -1,4 +1,4 @@
-import { app, ipcRenderer, IpcRendererEvent } from 'electron';
+import { ipcRenderer, IpcRendererEvent } from 'electron';
 
 export type Channels = 'peace';
 
@@ -25,7 +25,9 @@ const removeListener = (
   ipcRenderer.removeListener(channel, (_event, ...args) => func(...args));
 };
 
-const closeApp = () => app.quit();
+const closeApp = () => {
+  ipcRenderer.send('quit-app', []);
+};
 
 export default {
   ipcRenderer: {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -71,6 +71,10 @@ ipcMain.on('peace', async (event, arg) => {
   event.reply('peace', { result: res });
 });
 
+ipcMain.on('quit-app', () => {
+  app.quit();
+});
+
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support');
   sourceMapSupport.install();


### PR DESCRIPTION
Electron app module is only accessible in the main process. Hence, to close the app from the renderer side, one needs to send a msg to the main process to do it.

https://stackoverflow.com/questions/68481492/electron-how-to-close-app-via-js-in-2021