### PR TITLE
JAT-54 Parameterize filter type for each gain band

### DIFF
--- a/src/__tests__/unit_tests/Dropdown.test.tsx
+++ b/src/__tests__/unit_tests/Dropdown.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { setup } from '../utils/userEventUtils';
+import Dropdown from '../../renderer/Dropdown';
+import { FILTER_OPTIONS } from '../../renderer/icons/FilterTypeIcon';
+import { FilterTypeEnum } from '../../common/constants';
+
+describe('Dropdown', () => {
+  const name = 'dropdown';
+  const handleChange = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+  });
+
+  it('should render the dropdown', async () => {
+    const { user } = setup(
+      <Dropdown
+        name={name}
+        value={FilterTypeEnum.PEAK}
+        options={FILTER_OPTIONS}
+        handleChange={handleChange}
+      />
+    );
+
+    const value = screen.getByTitle('Peak Filter');
+    expect(value).toBeInTheDocument();
+    const dropdown = screen.getByLabelText(name);
+    await user.click(dropdown);
+    expect(screen.getByLabelText(`${name}-items`)).toBeInTheDocument();
+
+    const newValue = screen.getByTitle('Notch Filter');
+    expect(newValue).toBeInTheDocument();
+    await user.click(newValue);
+    expect(handleChange).toHaveBeenCalledWith(FilterTypeEnum.NO);
+  });
+});

--- a/src/__tests__/unit_tests/Dropdown.test.tsx
+++ b/src/__tests__/unit_tests/Dropdown.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { setup } from '../utils/userEventUtils';
 import Dropdown from '../../renderer/Dropdown';
 import { FILTER_OPTIONS } from '../../renderer/icons/FilterTypeIcon';
@@ -39,7 +39,7 @@ describe('Dropdown', () => {
     const { user } = setup(
       <Dropdown
         name={name}
-        value={FilterTypeEnum.LP}
+        value={FilterTypeEnum.LPQ}
         options={FILTER_OPTIONS}
         handleChange={handleChange}
       />
@@ -51,6 +51,53 @@ describe('Dropdown', () => {
     expect(item).toHaveFocus();
 
     await user.keyboard('{ArrowDown}{Enter}');
-    expect(handleChange).toHaveBeenCalledWith(FilterTypeEnum.HP);
+    expect(handleChange).toHaveBeenCalledWith(FilterTypeEnum.HPQ);
+  });
+
+  it('should close the dropdown when clicking outside', async () => {
+    const { user } = setup(
+      <div>
+        <Dropdown
+          name={name}
+          value={FilterTypeEnum.PEAK}
+          options={FILTER_OPTIONS}
+          handleChange={handleChange}
+        />
+        <div>Outside</div>
+      </div>
+    );
+
+    const dropdown = screen.getByLabelText(name);
+    await user.click(dropdown);
+    const item = screen.getByLabelText('Peak Filter');
+    expect(item).toHaveFocus();
+
+    await user.click(screen.getByText('Outside'));
+    expect(item).not.toBeInTheDocument();
+  });
+
+  it('should close the dropdown when focus moves outside', async () => {
+    const { user } = setup(
+      <div>
+        <Dropdown
+          name={name}
+          value={FilterTypeEnum.PEAK}
+          options={FILTER_OPTIONS}
+          handleChange={handleChange}
+        />
+        <button type="button">Outside</button>
+      </div>
+    );
+
+    const dropdown = screen.getByLabelText(name);
+    await user.click(dropdown);
+    const item = screen.getByLabelText('Peak Filter');
+    expect(item).toHaveFocus();
+
+    // Need this because the focus triggers a state update and so we need to wait
+    act(() => {
+      screen.getByText('Outside').focus();
+    });
+    expect(item).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/unit_tests/Dropdown.test.tsx
+++ b/src/__tests__/unit_tests/Dropdown.test.tsx
@@ -13,7 +13,7 @@ describe('Dropdown', () => {
     handleChange.mockClear();
   });
 
-  it('should render the dropdown', async () => {
+  it('should render the dropdown and click on an item', async () => {
     const { user } = setup(
       <Dropdown
         name={name}
@@ -29,9 +29,28 @@ describe('Dropdown', () => {
     await user.click(dropdown);
     expect(screen.getByLabelText(`${name}-items`)).toBeInTheDocument();
 
-    const newValue = screen.getByTitle('Notch Filter');
+    const newValue = screen.getByLabelText('Notch Filter');
     expect(newValue).toBeInTheDocument();
     await user.click(newValue);
     expect(handleChange).toHaveBeenCalledWith(FilterTypeEnum.NO);
+  });
+
+  it('should render the dropdown and select an item using keys', async () => {
+    const { user } = setup(
+      <Dropdown
+        name={name}
+        value={FilterTypeEnum.LP}
+        options={FILTER_OPTIONS}
+        handleChange={handleChange}
+      />
+    );
+
+    const dropdown = screen.getByLabelText(name);
+    await user.click(dropdown);
+    const item = screen.getByLabelText('Low Pass Filter');
+    expect(item).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(handleChange).toHaveBeenCalledWith(FilterTypeEnum.HP);
   });
 });

--- a/src/__tests__/unit_tests/Dropdown.test.tsx
+++ b/src/__tests__/unit_tests/Dropdown.test.tsx
@@ -19,6 +19,7 @@ describe('Dropdown', () => {
         name={name}
         value={FilterTypeEnum.PEAK}
         options={FILTER_OPTIONS}
+        isDisabled={false}
         handleChange={handleChange}
       />
     );
@@ -41,6 +42,7 @@ describe('Dropdown', () => {
         name={name}
         value={FilterTypeEnum.LPQ}
         options={FILTER_OPTIONS}
+        isDisabled={false}
         handleChange={handleChange}
       />
     );
@@ -54,6 +56,24 @@ describe('Dropdown', () => {
     expect(handleChange).toHaveBeenCalledWith(FilterTypeEnum.HPQ);
   });
 
+  it('should disable the dropdown', async () => {
+    const { user } = setup(
+      <Dropdown
+        name={name}
+        value={FilterTypeEnum.LPQ}
+        options={FILTER_OPTIONS}
+        isDisabled
+        handleChange={handleChange}
+      />
+    );
+
+    const value = screen.getByTitle('Low Pass Filter');
+    expect(value).toBeInTheDocument();
+    const dropdown = screen.getByLabelText(name);
+    await user.click(dropdown);
+    expect(screen.queryByLabelText('Low Pass Filter')).not.toBeInTheDocument();
+  });
+
   it('should close the dropdown when clicking outside', async () => {
     const { user } = setup(
       <div>
@@ -61,6 +81,7 @@ describe('Dropdown', () => {
           name={name}
           value={FilterTypeEnum.PEAK}
           options={FILTER_OPTIONS}
+          isDisabled={false}
           handleChange={handleChange}
         />
         <div>Outside</div>
@@ -83,6 +104,7 @@ describe('Dropdown', () => {
           name={name}
           value={FilterTypeEnum.PEAK}
           options={FILTER_OPTIONS}
+          isDisabled={false}
           handleChange={handleChange}
         />
         <button type="button">Outside</button>

--- a/src/common/channels.ts
+++ b/src/common/channels.ts
@@ -10,6 +10,8 @@ enum ChannelEnum {
   SET_FILTER_FREQUENCY = 'setFilterFrequency',
   GET_FILTER_QUALITY = 'getFilterQuality',
   SET_FILTER_QUALITY = 'setFilterQuality',
+  GET_FILTER_TYPE = 'getFilterType',
+  SET_FILTER_TYPE = 'setFilterType',
   GET_FILTER_COUNT = 'getFilterCount',
   ADD_FILTER = 'addFilter',
   REMOVE_FILTER = 'removeFilter',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -14,22 +14,24 @@ export const MAX_NUM_FILTERS = 20; // TODO: Investigate an appropriate value for
 export const MIN_NUM_FILTERS = 1;
 
 export enum FilterTypeEnum {
-  PEAK = 'PK', // ["PK",True,True]
-  LPQ = 'LPQ', // ["LPQ",False,True]
-  HPQ = 'HPQ', // ["HPQ",False,True]
-  BP = 'BP', // ["BP",False,True]
-  LS = 'LS', // ["LS",True,False]
-  HS = 'HS', // ["HS",True,False]
-  NO = 'NO', // ["NO",False,True]
-  AP = 'AP', // ["AP",False,True]
-  LSC = 'LSC', // ["LSC",True,True]
-  HSC = 'HSC', // ["HSC",True,True]
-  BWLP = 'BWLP', // ["BWLP",False,True]
-  BWHP = 'BWHP', // ["BWHP",False,True]
-  LRLP = 'LRLP', // ["LRLP",False,True]
-  LRHP = 'LRHP', // ["LRHP",False,True]
-  LSCQ = 'LSCQ', // ["LSCQ",True,True]
-  HSCQ = 'HSCQ', // ["HSCQ",True,True]
+  PEAK = 'PK', // Peak ["PK",True,True]
+  LP = 'LP', // Low Pass
+  HP = 'HP', // High Pass
+  LPQ = 'LPQ', // ?? ["LPQ",False,True]
+  HPQ = 'HPQ', // ?? ["HPQ",False,True]
+  BP = 'BP', // Band Pass ["BP",False,True]
+  LS = 'LS', // Low Shelf ["LS",True,False]
+  HS = 'HS', // High Shelf ["HS",True,False]
+  NO = 'NO', // Notch ["NO",False,True]
+  AP = 'AP', // All Pass ["AP",False,True]
+  LSC = 'LSC', // Low Shelf DB?? ["LSC",True,True]
+  HSC = 'HSC', // High Shelf DB?? ["HSC",True,True]
+  BWLP = 'BWLP', // Butterworth Low Pass ["BWLP",False,True]
+  BWHP = 'BWHP', // Butterworth High Pass ["BWHP",False,True]
+  LRLP = 'LRLP', // Linkwitz Riley Low Pass ["LRLP",False,True]
+  LRHP = 'LRHP', // Linkwitz Riley High Pass["LRHP",False,True]
+  LSCQ = 'LSCQ', // Low Shelf Q?? ["LSCQ",True,True]
+  HSCQ = 'HSCQ', // High Shelf Q?? ["HSCQ",True,True]
 }
 
 /** ----- Peace specific ----- */

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -13,19 +13,17 @@ export const MIN_QUALITY = 0.001;
 export const MAX_NUM_FILTERS = 20; // TODO: Investigate an appropriate value for this
 export const MIN_NUM_FILTERS = 1;
 
+// Need to use LPQ and HPQ to allow users to adjust quality for low/high pass filters
+// Need to use LSC and HSC to allow users to adjust quality for low/high shelf filters
 export enum FilterTypeEnum {
-  PEAK = 'PK', // Peak ["PK",True,True]
-  LP = 'LP', // Low Pass
-  HP = 'HP', // High Pass
-  LPQ = 'LPQ', // ?? ["LPQ",False,True]
-  HPQ = 'HPQ', // ?? ["HPQ",False,True]
+  PEAK = 'PK', // Peak ["PK",True,True] - Implemented
+  LPQ = 'LPQ', // Low Pass ["LPQ",False,True] - Implemented
+  HPQ = 'HPQ', // High Pass ["HPQ",False,True] - Implemented
   BP = 'BP', // Band Pass ["BP",False,True]
-  LS = 'LS', // Low Shelf ["LS",True,False]
-  HS = 'HS', // High Shelf ["HS",True,False]
-  NO = 'NO', // Notch ["NO",False,True]
+  NO = 'NO', // Notch ["NO",False,True] - Implemented
   AP = 'AP', // All Pass ["AP",False,True]
-  LSC = 'LSC', // Low Shelf DB?? ["LSC",True,True]
-  HSC = 'HSC', // High Shelf DB?? ["HSC",True,True]
+  LSC = 'LSC', // Low Shelf ["LSC",True,True] - Implemented
+  HSC = 'HSC', // High Shelf ["HSC",True,True] - Implemented
   BWLP = 'BWLP', // Butterworth Low Pass ["BWLP",False,True]
   BWHP = 'BWHP', // Butterworth High Pass ["BWHP",False,True]
   LRLP = 'LRLP', // Linkwitz Riley Low Pass ["LRLP",False,True]

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -13,6 +13,25 @@ export const MIN_QUALITY = 0.001;
 export const MAX_NUM_FILTERS = 20; // TODO: Investigate an appropriate value for this
 export const MIN_NUM_FILTERS = 1;
 
+export enum FilterTypeEnum {
+  PEAK = 'PK', // ["PK",True,True]
+  LPQ = 'LPQ', // ["LPQ",False,True]
+  HPQ = 'HPQ', // ["HPQ",False,True]
+  BP = 'BP', // ["BP",False,True]
+  LS = 'LS', // ["LS",True,False]
+  HS = 'HS', // ["HS",True,False]
+  NO = 'NO', // ["NO",False,True]
+  AP = 'AP', // ["AP",False,True]
+  LSC = 'LSC', // ["LSC",True,True]
+  HSC = 'HSC', // ["HSC",True,True]
+  BWLP = 'BWLP', // ["BWLP",False,True]
+  BWHP = 'BWHP', // ["BWHP",False,True]
+  LRLP = 'LRLP', // ["LRLP",False,True]
+  LRHP = 'LRHP', // ["LRHP",False,True]
+  LSCQ = 'LSCQ', // ["LSCQ",True,True]
+  HSCQ = 'HSCQ', // ["HSCQ",True,True]
+}
+
 /** ----- Peace specific ----- */
 
 // Peace returns numerical values as unsigned integers

--- a/src/main/flush.ts
+++ b/src/main/flush.ts
@@ -1,24 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-
-export enum FilterTypeEnum {
-  PEAK = 'PK', // ["PK",True,True]
-  LPQ = 'LPQ', // ["LPQ",False,True]
-  HPQ = 'HPQ', // ["HPQ",False,True]
-  BP = 'BP', // ["BP",False,True]
-  LS = 'LS', // ["LS",True,False]
-  HS = 'HS', // ["HS",True,False]
-  NO = 'NO', // ["NO",False,True]
-  AP = 'AP', // ["AP",False,True]
-  LSC = 'LSC', // ["LSC",True,True]
-  HSC = 'HSC', // ["HSC",True,True]
-  BWLP = 'BWLP', // ["BWLP",False,True]
-  BWHP = 'BWHP', // ["BWHP",False,True]
-  LRLP = 'LRLP', // ["LRLP",False,True]
-  LRHP = 'LRHP', // ["LRHP",False,True]
-  LSCQ = 'LSCQ', // ["LSCQ",True,True]
-  HSCQ = 'HSCQ', // ["HSCQ",True,True]
-}
+import { FilterTypeEnum } from '../common/constants';
 
 interface IFilter {
   frequency: number;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -26,6 +26,7 @@ import { resolveHtmlPath } from './util';
 import { getConfigPath, isEqualizerAPOInstalled } from './registry';
 import ChannelEnum from '../common/channels';
 import {
+  FilterTypeEnum,
   MAX_FREQUENCY,
   MAX_GAIN,
   MAX_NUM_FILTERS,
@@ -265,6 +266,42 @@ ipcMain.on(ChannelEnum.SET_FILTER_QUALITY, async (event, arg) => {
   }
 
   state.filters[filterIndex].quality = quality;
+  await handleUpdate(event, channel + filterIndex);
+});
+
+ipcMain.on(ChannelEnum.GET_FILTER_TYPE, async (event, arg) => {
+  const channel = ChannelEnum.GET_FILTER_TYPE;
+  const filterIndex = parseInt(arg[0], 10) || 0;
+
+  // Filter index must be within the length of the filters array
+  if (filterIndex < 0 || filterIndex >= state.filters.length) {
+    handleError(event, channel + filterIndex, ErrorCode.INVALID_PARAMETER);
+    return;
+  }
+
+  const reply: TSuccess = {
+    result: state.filters[filterIndex].type,
+  };
+  event.reply(channel + filterIndex, reply);
+});
+
+ipcMain.on(ChannelEnum.SET_FILTER_TYPE, async (event, arg) => {
+  const channel = ChannelEnum.SET_FILTER_TYPE;
+  const filterIndex = parseInt(arg[0], 10) || 0;
+  const filterType = arg[1];
+
+  // Filter index must be within the length of the filters array
+  if (filterIndex < 0 || filterIndex >= state.filters.length) {
+    handleError(event, channel + filterIndex, ErrorCode.INVALID_PARAMETER);
+    return;
+  }
+
+  if (!Object.values(FilterTypeEnum).includes(filterType)) {
+    handleError(event, channel + filterIndex, ErrorCode.INVALID_PARAMETER);
+    return;
+  }
+
+  state.filters[filterIndex].type = filterType as FilterTypeEnum;
   await handleUpdate(event, channel + filterIndex);
 });
 

--- a/src/renderer/Dropdown.tsx
+++ b/src/renderer/Dropdown.tsx
@@ -32,25 +32,33 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
     [options]
   );
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const labelRef = useRef<HTMLLabelElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isOpen) {
-      const index = options.findIndex((entry) => entry.value === value);
+      // Focus on the selected dropdown item when opened
+      const index = Math.max(
+        options.findIndex((entry) => entry.value === value),
+        // Default to the first option if the value isn't valid
+        0
+      );
       inputRefs[index].current?.focus();
     }
   }, [inputRefs, isOpen, options, value]);
 
-  useClickOutside<HTMLLabelElement>(labelRef, () => {
+  // Close the dropdown if the user clicks outside of the dropdown
+  useClickOutside<HTMLDivElement>(dropdownRef, () => {
     setIsOpen(false);
   });
 
-  useFocusOutside<HTMLLabelElement>(labelRef, () => {
+  // Close the dropdown if the user tabs outside of the dropdown
+  useFocusOutside<HTMLDivElement>(dropdownRef, () => {
     setIsOpen(false);
   });
 
   const selectedEntry = useMemo(
-    () => options.find((e) => e.value === value)?.display,
+    // Default to the first option if the value isn't valid
+    () => (options.find((e) => e.value === value) || options[0]).display,
     [options, value]
   );
 
@@ -86,7 +94,7 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
   };
 
   return (
-    <label htmlFor={name} ref={labelRef} className="dropdown">
+    <div ref={dropdownRef} className="dropdown">
       <div
         role="menu"
         aria-label={name}
@@ -120,7 +128,7 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
           })}
         </ul>
       )}
-    </label>
+    </div>
   );
 };
 

--- a/src/renderer/Dropdown.tsx
+++ b/src/renderer/Dropdown.tsx
@@ -1,0 +1,111 @@
+import { ChangeEvent, KeyboardEvent, useMemo, useRef, useState } from 'react';
+import ArrowIcon from './icons/ArrowIcon';
+import './styles/Dropdown.scss';
+import { useClickOutside } from './utils';
+
+interface IOptionEntry {
+  value: string;
+  display: JSX.Element | string;
+}
+
+interface IDropdownProps {
+  name: string;
+  options: IOptionEntry[];
+  value: string;
+  handleChange: (newValue: string) => void;
+}
+
+export const SimpleDropdown = ({
+  name,
+  options,
+  value,
+  handleChange,
+}: IDropdownProps) => {
+  const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value: newValue } = e.target;
+    handleChange(newValue);
+  };
+
+  return (
+    <label htmlFor={name} className="dropdown">
+      <select name={name} aria-label={name} value={value} onChange={onChange}>
+        {options.map((entry: IOptionEntry) => {
+          return <option value={entry.value}>{entry.display}</option>;
+        })}
+      </select>
+    </label>
+  );
+};
+
+const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const labelRef = useRef<HTMLLabelElement>(null);
+
+  useClickOutside<HTMLLabelElement>(labelRef, () => {
+    setIsOpen(false);
+  });
+
+  const selectedEntry = useMemo(
+    () => options.find((e) => e.value === value)?.display,
+    [options, value]
+  );
+
+  const toggleIsOpen = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const listenForEnter = (e: KeyboardEvent) => {
+    if (e.code === 'Enter') {
+      toggleIsOpen();
+    }
+  };
+
+  const onChange = (newValue: string) => {
+    handleChange(newValue);
+    setIsOpen(false);
+  };
+
+  const handleItemKeyPress = (e: KeyboardEvent, entry: IOptionEntry) => {
+    if (e.code === 'Enter') {
+      onChange(entry.value);
+    } else if (e.code === 'Down') {
+      // TODO: Allow users to use up and down arrows to change between options
+    }
+  };
+
+  return (
+    <label htmlFor={name} ref={labelRef} className="dropdown">
+      <div
+        role="menu"
+        className="row"
+        onClick={toggleIsOpen}
+        onKeyDown={listenForEnter}
+        tabIndex={0}
+      >
+        {selectedEntry}
+        <ArrowIcon type="down" className="arrow" />
+      </div>
+      {isOpen && (
+        <ul aria-label={name}>
+          {options.map((entry: IOptionEntry) => {
+            return (
+              <li
+                role="menuitem"
+                className="row"
+                key={entry.value}
+                value={entry.value}
+                onClick={() => onChange(entry.value)}
+                onKeyDown={(e) => handleItemKeyPress(e, entry)}
+                tabIndex={0}
+              >
+                {entry.display}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </label>
+  );
+};
+
+export default Dropdown;

--- a/src/renderer/Dropdown.tsx
+++ b/src/renderer/Dropdown.tsx
@@ -1,7 +1,7 @@
-import { ChangeEvent, KeyboardEvent, useMemo, useRef, useState } from 'react';
+import { KeyboardEvent, useMemo, useRef, useState } from 'react';
 import ArrowIcon from './icons/ArrowIcon';
 import './styles/Dropdown.scss';
-import { useClickOutside } from './utils';
+import { useClickOutside, useFocusOutside } from './utils';
 
 interface IOptionEntry {
   value: string;
@@ -15,33 +15,15 @@ interface IDropdownProps {
   handleChange: (newValue: string) => void;
 }
 
-export const SimpleDropdown = ({
-  name,
-  options,
-  value,
-  handleChange,
-}: IDropdownProps) => {
-  const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const { value: newValue } = e.target;
-    handleChange(newValue);
-  };
-
-  return (
-    <label htmlFor={name} className="dropdown">
-      <select name={name} aria-label={name} value={value} onChange={onChange}>
-        {options.map((entry: IOptionEntry) => {
-          return <option value={entry.value}>{entry.display}</option>;
-        })}
-      </select>
-    </label>
-  );
-};
-
 const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const labelRef = useRef<HTMLLabelElement>(null);
 
   useClickOutside<HTMLLabelElement>(labelRef, () => {
+    setIsOpen(false);
+  });
+
+  useFocusOutside<HTMLLabelElement>(labelRef, () => {
     setIsOpen(false);
   });
 
@@ -77,6 +59,7 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
     <label htmlFor={name} ref={labelRef} className="dropdown">
       <div
         role="menu"
+        aria-label={name}
         className="row"
         onClick={toggleIsOpen}
         onKeyDown={listenForEnter}
@@ -86,7 +69,7 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
         <ArrowIcon type="down" className="arrow" />
       </div>
       {isOpen && (
-        <ul aria-label={name}>
+        <ul aria-label={`${name}-items`}>
           {options.map((entry: IOptionEntry) => {
             return (
               <li

--- a/src/renderer/Dropdown.tsx
+++ b/src/renderer/Dropdown.tsx
@@ -20,10 +20,17 @@ interface IDropdownProps {
   name: string;
   options: IOptionEntry[];
   value: string;
+  isDisabled: boolean;
   handleChange: (newValue: string) => void;
 }
 
-const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
+const Dropdown = ({
+  name,
+  options,
+  value,
+  isDisabled,
+  handleChange,
+}: IDropdownProps) => {
   const inputRefs = useMemo(
     () =>
       Array(options.length)
@@ -33,6 +40,12 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
   );
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isDisabled) {
+      setIsOpen(false);
+    }
+  }, [isDisabled]);
 
   useEffect(() => {
     if (isOpen) {
@@ -66,7 +79,17 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
     setIsOpen(!isOpen);
   };
 
+  const handleClick = () => {
+    if (isDisabled) {
+      return;
+    }
+    toggleIsOpen();
+  };
+
   const listenForEnter = (e: KeyboardEvent) => {
+    if (isDisabled) {
+      return;
+    }
     if (e.code === 'Enter') {
       toggleIsOpen();
     }
@@ -82,6 +105,9 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
     entry: IOptionEntry,
     index: number
   ) => {
+    if (isDisabled) {
+      return;
+    }
     if (e.code === 'Enter') {
       onChange(entry.value);
     } else if (e.code === 'ArrowDown') {
@@ -98,10 +124,11 @@ const Dropdown = ({ name, options, value, handleChange }: IDropdownProps) => {
       <div
         role="menu"
         aria-label={name}
+        aria-disabled={isDisabled}
         className="row"
-        onClick={toggleIsOpen}
+        onClick={handleClick}
         onKeyDown={listenForEnter}
-        tabIndex={0}
+        tabIndex={isDisabled ? -1 : 0}
       >
         {selectedEntry}
         <ArrowIcon type="down" className="arrow" />

--- a/src/renderer/Dropdown.tsx
+++ b/src/renderer/Dropdown.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  createElement,
 } from 'react';
 import ArrowIcon from './icons/ArrowIcon';
 import './styles/Dropdown.scss';
@@ -31,6 +32,7 @@ const Dropdown = ({
   isDisabled,
   handleChange,
 }: IDropdownProps) => {
+  const nullElement = createElement('div');
   const inputRefs = useMemo(
     () =>
       Array(options.length)
@@ -71,7 +73,7 @@ const Dropdown = ({
 
   const selectedEntry = useMemo(
     // Default to the first option if the value isn't valid
-    () => (options.find((e) => e.value === value) || options[0]).display,
+    () => options.find((e) => e.value === value)?.display,
     [options, value]
   );
 
@@ -130,7 +132,7 @@ const Dropdown = ({
         onKeyDown={listenForEnter}
         tabIndex={isDisabled ? -1 : 0}
       >
-        {selectedEntry}
+        {selectedEntry || nullElement}
         <ArrowIcon type="down" className="arrow" />
       </div>
       {isOpen && (

--- a/src/renderer/FrequencyBand.tsx
+++ b/src/renderer/FrequencyBand.tsx
@@ -32,12 +32,24 @@ const options = [
     display: <FilterTypeIcon type={FilterTypeEnum.PEAK} />,
   },
   {
-    value: FilterTypeEnum.NO,
-    display: <FilterTypeIcon type={FilterTypeEnum.NO} />,
+    value: FilterTypeEnum.LP,
+    display: <FilterTypeIcon type={FilterTypeEnum.LP} />,
   },
   {
-    value: 'test',
-    display: 'Test',
+    value: FilterTypeEnum.HP,
+    display: <FilterTypeIcon type={FilterTypeEnum.HP} />,
+  },
+  {
+    value: FilterTypeEnum.LS,
+    display: <FilterTypeIcon type={FilterTypeEnum.LS} />,
+  },
+  {
+    value: FilterTypeEnum.HS,
+    display: <FilterTypeIcon type={FilterTypeEnum.HS} />,
+  },
+  {
+    value: FilterTypeEnum.NO,
+    display: <FilterTypeIcon type={FilterTypeEnum.NO} />,
   },
 ];
 

--- a/src/renderer/FrequencyBand.tsx
+++ b/src/renderer/FrequencyBand.tsx
@@ -14,9 +14,11 @@ import {
   getFrequency,
   getGain,
   getQuality,
+  getType,
   setFrequency,
   setGain,
   setQuality,
+  setType,
 } from './equalizerApi';
 import NumberInput from './NumberInput';
 import { AquaContext } from './AquaContext';
@@ -57,6 +59,7 @@ const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
         setActualFrequency(result);
         result = await getQuality(sliderIndex);
         setActualQuality(result);
+        setFilterType(await getType(sliderIndex));
       } catch (e) {
         setGlobalError(e as ErrorDescription);
       }
@@ -82,6 +85,15 @@ const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
     }
   };
 
+  const handleFilterTypeSubmit = async (newValue: string) => {
+    try {
+      await setType(sliderIndex, newValue);
+      setFilterType(newValue);
+    } catch (e) {
+      setGlobalError(e as ErrorDescription);
+    }
+  };
+
   const getSliderGain = useCallback(() => getGain(sliderIndex), [sliderIndex]);
 
   return (
@@ -90,7 +102,7 @@ const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
         name={`${actualFrequency}-filter-type`}
         value={filterType}
         options={options}
-        handleChange={(newValue) => setFilterType(newValue)}
+        handleChange={handleFilterTypeSubmit}
       />
       <NumberInput
         value={actualFrequency}

--- a/src/renderer/FrequencyBand.tsx
+++ b/src/renderer/FrequencyBand.tsx
@@ -87,6 +87,7 @@ const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
         name={`${actualFrequency}-filter-type`}
         value={filterType}
         options={FILTER_OPTIONS}
+        isDisabled={!!globalError}
         handleChange={handleFilterTypeSubmit}
       />
       <NumberInput

--- a/src/renderer/FrequencyBand.tsx
+++ b/src/renderer/FrequencyBand.tsx
@@ -24,34 +24,7 @@ import NumberInput from './NumberInput';
 import { AquaContext } from './AquaContext';
 import Slider from './Slider';
 import './styles/MainContent.scss';
-import FilterTypeIcon from './icons/FilterTypeIcon';
-
-const options = [
-  {
-    value: FilterTypeEnum.PEAK,
-    display: <FilterTypeIcon type={FilterTypeEnum.PEAK} />,
-  },
-  {
-    value: FilterTypeEnum.LP,
-    display: <FilterTypeIcon type={FilterTypeEnum.LP} />,
-  },
-  {
-    value: FilterTypeEnum.HP,
-    display: <FilterTypeIcon type={FilterTypeEnum.HP} />,
-  },
-  {
-    value: FilterTypeEnum.LS,
-    display: <FilterTypeIcon type={FilterTypeEnum.LS} />,
-  },
-  {
-    value: FilterTypeEnum.HS,
-    display: <FilterTypeIcon type={FilterTypeEnum.HS} />,
-  },
-  {
-    value: FilterTypeEnum.NO,
-    display: <FilterTypeIcon type={FilterTypeEnum.NO} />,
-  },
-];
+import { FILTER_OPTIONS } from './icons/FilterTypeIcon';
 
 interface IFrequencyBandProps {
   sliderIndex: number;
@@ -113,7 +86,7 @@ const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
       <Dropdown
         name={`${actualFrequency}-filter-type`}
         value={filterType}
-        options={options}
+        options={FILTER_OPTIONS}
         handleChange={handleFilterTypeSubmit}
       />
       <NumberInput

--- a/src/renderer/FrequencyBand.tsx
+++ b/src/renderer/FrequencyBand.tsx
@@ -1,5 +1,6 @@
 import { ErrorDescription } from 'common/errors';
 import {
+  FilterTypeEnum,
   MAX_FREQUENCY,
   MAX_GAIN,
   MAX_QUALITY,
@@ -8,6 +9,7 @@ import {
   MIN_QUALITY,
 } from 'common/constants';
 import { useCallback, useContext, useEffect, useState } from 'react';
+import Dropdown from './Dropdown';
 import {
   getFrequency,
   getGain,
@@ -20,6 +22,22 @@ import NumberInput from './NumberInput';
 import { AquaContext } from './AquaContext';
 import Slider from './Slider';
 import './styles/MainContent.scss';
+import FilterTypeIcon from './icons/FilterTypeIcon';
+
+const options = [
+  {
+    value: FilterTypeEnum.PEAK,
+    display: <FilterTypeIcon type={FilterTypeEnum.PEAK} />,
+  },
+  {
+    value: FilterTypeEnum.NO,
+    display: <FilterTypeIcon type={FilterTypeEnum.NO} />,
+  },
+  {
+    value: 'test',
+    display: 'Test',
+  },
+];
 
 interface IFrequencyBandProps {
   sliderIndex: number;
@@ -28,6 +46,7 @@ interface IFrequencyBandProps {
 const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
   const [actualFrequency, setActualFrequency] = useState<number>(0);
   const [actualQuality, setActualQuality] = useState<number>(0);
+  const [filterType, setFilterType] = useState<string>(FilterTypeEnum.PEAK);
 
   const { globalError, setGlobalError } = useContext(AquaContext);
 
@@ -67,6 +86,12 @@ const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
 
   return (
     <div className="col band">
+      <Dropdown
+        name={`${actualFrequency}-filter-type`}
+        value={filterType}
+        options={options}
+        handleChange={(newValue) => setFilterType(newValue)}
+      />
       <NumberInput
         value={actualFrequency}
         min={MIN_FREQUENCY}
@@ -84,16 +109,16 @@ const FrequencyBand = ({ sliderIndex }: IFrequencyBandProps) => {
           getValue={getSliderGain}
           setValue={(newValue: number) => setGain(sliderIndex, newValue)}
         />
-        <NumberInput
-          value={actualQuality}
-          min={MIN_QUALITY}
-          max={MAX_QUALITY}
-          name={`${actualQuality}`}
-          isDisabled={!!globalError}
-          floatPrecision={3}
-          handleSubmit={handleQualitySubmit}
-        />
       </div>
+      <NumberInput
+        value={actualQuality}
+        min={MIN_QUALITY}
+        max={MAX_QUALITY}
+        name={`${actualQuality}`}
+        isDisabled={!!globalError}
+        floatPrecision={3}
+        handleSubmit={handleQualitySubmit}
+      />
     </div>
   );
 };

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -1,9 +1,5 @@
 import { ErrorDescription } from 'common/errors';
-import {
-  FilterTypeEnum,
-  MAX_NUM_FILTERS,
-  MIN_NUM_FILTERS,
-} from 'common/constants';
+import { MAX_NUM_FILTERS, MIN_NUM_FILTERS } from 'common/constants';
 import { useContext, useEffect, useState } from 'react';
 import {
   addEqualizerSlider,

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -57,7 +57,7 @@ const MainContent = () => {
   return (
     <>
       {sliderIndices.length === 0 ? (
-        <div className="center row">
+        <div className="center full row">
           <h1>Loading...</h1>
         </div>
       ) : (

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -57,7 +57,9 @@ const MainContent = () => {
   return (
     <>
       {sliderIndices.length === 0 ? (
-        <h1>Loading...</h1>
+        <div className="center row">
+          <h1>Loading...</h1>
+        </div>
       ) : (
         <div className="center mainContent">
           <div className="col center bandLabel">

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -1,5 +1,9 @@
 import { ErrorDescription } from 'common/errors';
-import { MAX_NUM_FILTERS, MIN_NUM_FILTERS } from 'common/constants';
+import {
+  FilterTypeEnum,
+  MAX_NUM_FILTERS,
+  MIN_NUM_FILTERS,
+} from 'common/constants';
 import { useContext, useEffect, useState } from 'react';
 import {
   addEqualizerSlider,
@@ -55,12 +59,13 @@ const MainContent = () => {
   };
 
   return (
-    <div className="row center mainContent">
+    <>
       {sliderIndices.length === 0 ? (
         <h1>Loading...</h1>
       ) : (
-        <>
+        <div className="center mainContent">
           <div className="col center bandLabel">
+            <span className="rowLabel">Filter Type</span>
             <span className="rowLabel">Frequency (Hz)</span>
             <div className="col">
               <span>30dB</span>
@@ -70,13 +75,15 @@ const MainContent = () => {
             <span className="rowLabel">Gain (dB)</span>
             <span className="rowLabel">Quality</span>
           </div>
-          {sliderIndices.map((sliderIndex) => (
-            <FrequencyBand
-              sliderIndex={sliderIndex}
-              key={`slider-${sliderIndex}`}
-            />
-          ))}
-          <div className="col sliderButtons">
+          <div className="bands row center">
+            {sliderIndices.map((sliderIndex) => (
+              <FrequencyBand
+                sliderIndex={sliderIndex}
+                key={`slider-${sliderIndex}`}
+              />
+            ))}
+          </div>
+          <div className="col center sliderButtons">
             <Button
               ariaLabel="Add Equalizer Slider"
               isDisabled={sliderIndices.length >= MAX_NUM_FILTERS}
@@ -94,9 +101,9 @@ const MainContent = () => {
               <MinusIcon />
             </Button>
           </div>
-        </>
+        </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/renderer/NumberInput.tsx
+++ b/src/renderer/NumberInput.tsx
@@ -119,7 +119,7 @@ const NumberInput = ({
     }
 
     // Prevent user from typing numbers that are too large or use more than 7 characters
-    if (Math.abs(num) > 10000 || input.length > 7) {
+    if (Math.abs(num) >= 100000 || input.length > 7) {
       return;
     }
 

--- a/src/renderer/NumberInput.tsx
+++ b/src/renderer/NumberInput.tsx
@@ -185,7 +185,7 @@ const NumberInput = ({
   return (
     <label
       htmlFor={name}
-      className="numberInput col center"
+      className="numberInput"
       // the ch unit supposedly uses the '0' as the per character valueLength
       style={{ '--input-width': `${valueLength}ch` } as CSSProperties}
     >

--- a/src/renderer/equalizerApi.ts
+++ b/src/renderer/equalizerApi.ts
@@ -72,11 +72,12 @@ const buildResponseHandler = <Type extends string | number | boolean | void>(
   };
 };
 
-const simpleResponseHandler = buildResponseHandler<number>(
-  (result, resolve) => {
+const simpleResponseHandler = <
+  Type extends string | number | boolean | void
+>() =>
+  buildResponseHandler<Type>((result, resolve) => {
     resolve(result);
-  }
-);
+  });
 
 const setterResponseHandler = buildResponseHandler<void>((_result, resolve) =>
   resolve()
@@ -120,10 +121,7 @@ export const getEqualizerStatus = (): Promise<boolean> => {
   const channel = ChannelEnum.GET_ENABLE;
   window.electron.ipcRenderer.sendMessage(channel, []);
 
-  const responseHandler = buildResponseHandler<boolean>((result, resolve) =>
-    resolve(result)
-  );
-  return promisifyResult(responseHandler, channel);
+  return promisifyResult(simpleResponseHandler<boolean>(), channel);
 };
 
 /**
@@ -133,7 +131,7 @@ export const getEqualizerStatus = (): Promise<boolean> => {
 export const getMainPreAmp = (): Promise<number> => {
   const channel = ChannelEnum.GET_PREAMP;
   window.electron.ipcRenderer.sendMessage(channel, []);
-  return promisifyResult(simpleResponseHandler, channel);
+  return promisifyResult(simpleResponseHandler<number>(), channel);
 };
 
 /**
@@ -159,7 +157,7 @@ export const setMainPreAmp = (gain: number) => {
 export const getGain = (index: number): Promise<number> => {
   const channel = ChannelEnum.GET_FILTER_GAIN;
   window.electron.ipcRenderer.sendMessage(channel, [index]);
-  return promisifyResult(simpleResponseHandler, channel + index);
+  return promisifyResult(simpleResponseHandler<number>(), channel + index);
 };
 
 /**
@@ -186,7 +184,7 @@ export const setGain = (index: number, gain: number) => {
 export const getFrequency = (index: number): Promise<number> => {
   const channel = ChannelEnum.GET_FILTER_FREQUENCY;
   window.electron.ipcRenderer.sendMessage(channel, [index]);
-  return promisifyResult(simpleResponseHandler, channel + index);
+  return promisifyResult(simpleResponseHandler<number>(), channel + index);
 };
 
 /**
@@ -213,7 +211,7 @@ export const setFrequency = (index: number, frequency: number) => {
 export const getQuality = (index: number): Promise<number> => {
   const channel = ChannelEnum.GET_FILTER_QUALITY;
   window.electron.ipcRenderer.sendMessage(channel, [index]);
-  return promisifyResult(simpleResponseHandler, channel + index);
+  return promisifyResult(simpleResponseHandler<number>(), channel + index);
 };
 
 /**
@@ -241,9 +239,7 @@ export const getType = (index: number): Promise<FilterTypeEnum> => {
   const channel = ChannelEnum.GET_FILTER_TYPE;
   window.electron.ipcRenderer.sendMessage(channel, [index]);
   return promisifyResult<FilterTypeEnum>(
-    buildResponseHandler<FilterTypeEnum>((result, resolve) => {
-      resolve(result);
-    }),
+    simpleResponseHandler<FilterTypeEnum>(),
     channel + index
   );
 };
@@ -266,7 +262,7 @@ export const setType = (index: number, filterType: string) => {
 export const getEqualizerSliderCount = (): Promise<number> => {
   const channel = ChannelEnum.GET_FILTER_COUNT;
   window.electron.ipcRenderer.sendMessage(channel, []);
-  return promisifyResult(simpleResponseHandler, channel);
+  return promisifyResult(simpleResponseHandler<number>(), channel);
 };
 
 /**

--- a/src/renderer/equalizerApi.ts
+++ b/src/renderer/equalizerApi.ts
@@ -5,6 +5,7 @@ import {
   getErrorDescription,
 } from 'common/errors';
 import {
+  FilterTypeEnum,
   MAX_FREQUENCY,
   MAX_GAIN,
   MAX_QUALITY,
@@ -16,7 +17,7 @@ import {
 const TIMEOUT = 10000;
 
 export interface TSuccess {
-  result: number;
+  result: number | string;
 }
 
 export interface TError {
@@ -50,9 +51,9 @@ const promisifyResult = <Type>(
   });
 };
 
-const buildResponseHandler = <Type>(
+const buildResponseHandler = <Type extends string | number | boolean | void>(
   resultEvaluator: (
-    result: number,
+    result: Type,
     resolve: (value: Type | PromiseLike<Type>) => void,
     reject: (reason?: ErrorDescription) => void
   ) => void
@@ -67,7 +68,7 @@ const buildResponseHandler = <Type>(
       return;
     }
     const { result } = arg as TSuccess;
-    resultEvaluator(result, resolve, reject);
+    resultEvaluator(result as Type, resolve, reject);
   };
 };
 
@@ -77,13 +78,8 @@ const simpleResponseHandler = buildResponseHandler<number>(
   }
 );
 
-const setterResponseHandler = buildResponseHandler<void>(
-  (result, resolve, reject) => {
-    if (result !== 1) {
-      reject(getErrorDescription(ErrorCode.FAILURE));
-    }
-    resolve();
-  }
+const setterResponseHandler = buildResponseHandler<void>((_result, resolve) =>
+  resolve()
 );
 
 /**
@@ -125,7 +121,7 @@ export const getEqualizerStatus = (): Promise<boolean> => {
   window.electron.ipcRenderer.sendMessage(channel, []);
 
   const responseHandler = buildResponseHandler<boolean>((result, resolve) =>
-    resolve(result === 1)
+    resolve(result)
   );
   return promisifyResult(responseHandler, channel);
 };
@@ -233,6 +229,33 @@ export const setQuality = (index: number, quality: number) => {
     );
   }
   window.electron.ipcRenderer.sendMessage(channel, [index, quality]);
+  return promisifyResult(setterResponseHandler, channel + index);
+};
+
+/**
+ * Get a slider's quality
+ * @param {number} index - index of the slider being adjusted
+ * @returns { Promise<FilterTypeEnum> } filter type - value in FilterTypeEnum
+ */
+export const getType = (index: number): Promise<FilterTypeEnum> => {
+  const channel = ChannelEnum.GET_FILTER_TYPE;
+  window.electron.ipcRenderer.sendMessage(channel, [index]);
+  return promisifyResult<FilterTypeEnum>(
+    buildResponseHandler<FilterTypeEnum>((result, resolve) => {
+      resolve(result);
+    }),
+    channel + index
+  );
+};
+
+/**
+ * Adjusts a slider's quality
+ * @param {number} index - index of the slider being adjusted
+ * @param {string} filterType - new filter type
+ */
+export const setType = (index: number, filterType: string) => {
+  const channel = ChannelEnum.SET_FILTER_TYPE;
+  window.electron.ipcRenderer.sendMessage(channel, [index, filterType]);
   return promisifyResult(setterResponseHandler, channel + index);
 };
 

--- a/src/renderer/icons/ArrowIcon.tsx
+++ b/src/renderer/icons/ArrowIcon.tsx
@@ -1,8 +1,8 @@
 const ArrowIcon = ({
-  className,
+  className = '',
   type,
 }: {
-  className: string;
+  className?: string;
   type: 'up' | 'down';
 }) => {
   switch (type) {

--- a/src/renderer/icons/ArrowIcon.tsx
+++ b/src/renderer/icons/ArrowIcon.tsx
@@ -1,4 +1,10 @@
-const ArrowIcon = ({ type }: { type: 'up' | 'down' }) => {
+const ArrowIcon = ({
+  className,
+  type,
+}: {
+  className: string;
+  type: 'up' | 'down';
+}) => {
   switch (type) {
     case 'up':
       return (
@@ -8,6 +14,7 @@ const ArrowIcon = ({ type }: { type: 'up' | 'down' }) => {
           viewBox="0 0 28 23"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
+          className={className}
         >
           <g filter="url(#filter0_d_413_31)">
             <path
@@ -62,6 +69,7 @@ const ArrowIcon = ({ type }: { type: 'up' | 'down' }) => {
           viewBox="0 0 28 23"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
+          className={className}
         >
           <g filter="url(#filter0_d_413_49)">
             <path

--- a/src/renderer/icons/FilterTypeIcon.tsx
+++ b/src/renderer/icons/FilterTypeIcon.tsx
@@ -19,7 +19,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           />
         </svg>
       );
-    case FilterTypeEnum.LP:
+    case FilterTypeEnum.LPQ:
       return (
         <svg
           width="32"
@@ -36,7 +36,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           />
         </svg>
       );
-    case FilterTypeEnum.HP:
+    case FilterTypeEnum.HPQ:
       return (
         <svg
           width="32"
@@ -53,7 +53,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           />
         </svg>
       );
-    case FilterTypeEnum.LS:
+    case FilterTypeEnum.LSC:
       return (
         <svg
           width="32"
@@ -70,7 +70,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           />
         </svg>
       );
-    case FilterTypeEnum.HS:
+    case FilterTypeEnum.HSC:
       return (
         <svg
           width="32"
@@ -116,24 +116,24 @@ export const FILTER_OPTIONS = [
     display: <FilterTypeIcon type={FilterTypeEnum.PEAK} />,
   },
   {
-    value: FilterTypeEnum.LP,
+    value: FilterTypeEnum.LPQ,
     label: 'Low Pass Filter',
-    display: <FilterTypeIcon type={FilterTypeEnum.LP} />,
+    display: <FilterTypeIcon type={FilterTypeEnum.LPQ} />,
   },
   {
-    value: FilterTypeEnum.HP,
+    value: FilterTypeEnum.HPQ,
     label: 'High Pass Filter',
-    display: <FilterTypeIcon type={FilterTypeEnum.HP} />,
+    display: <FilterTypeIcon type={FilterTypeEnum.HPQ} />,
   },
   {
-    value: FilterTypeEnum.LS,
+    value: FilterTypeEnum.LSC,
     label: 'Low Shelf Filter',
-    display: <FilterTypeIcon type={FilterTypeEnum.LS} />,
+    display: <FilterTypeIcon type={FilterTypeEnum.LSC} />,
   },
   {
-    value: FilterTypeEnum.HS,
+    value: FilterTypeEnum.HSC,
     label: 'High Shelf Filter',
-    display: <FilterTypeIcon type={FilterTypeEnum.HS} />,
+    display: <FilterTypeIcon type={FilterTypeEnum.HSC} />,
   },
   {
     value: FilterTypeEnum.NO,

--- a/src/renderer/icons/FilterTypeIcon.tsx
+++ b/src/renderer/icons/FilterTypeIcon.tsx
@@ -11,6 +11,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title>Peak Filter</title>
           <path
             d="M0 14C0 14 5.77285 14 8.64969 14C11.5265 14 13.4444 2 15.9377 2C18.4309 2 20.3488 14 23.6092 14C26.8696 14 32 14 32 14"
             stroke="#4F6EF7"
@@ -27,6 +28,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title>Low Pass Filter</title>
           <path
             d="M1 2C1 2 10.5 2 13.5 2C16.5 2 20.5 7.50024 22 10.0002C23.5 12.5002 24.5 15.5002 24.5 16.0002"
             stroke="#F7844F"
@@ -43,6 +45,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title>High Pass Filter</title>
           <path
             d="M32 2C32 2 22.5 2 19.5 2C16.5 2 12.5 7.50024 11 10.0002C9.5 12.5002 8.5 15.5002 8.5 16.0002"
             stroke="#4FF7D8"
@@ -59,6 +62,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title>Low Shelf Filter</title>
           <path
             d="M1 2.00002C1 2.00002 4.39077 1.99996 8 2C11.6092 2.00004 16.2396 14 19.5 14C22.7604 14 32 14 32 14"
             stroke="#F74FC2"
@@ -75,6 +79,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title>High Shelf Filter</title>
           <path
             d="M32 2.00002C32 2.00002 28.6092 1.99996 25 2C21.3908 2.00004 16.7604 14 13.5 14C10.2396 14 1 14 1 14"
             stroke="#844FF7"
@@ -91,6 +96,7 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title>Notch Filter</title>
           <path
             d="M32 2C32 2 26.2271 2 23.3503 2C20.4735 2 18.5556 14 16.0623 14C13.5691 14 11.6512 2 8.39077 2C5.13036 2 0 2 0 2"
             stroke="#F74F6E"
@@ -102,5 +108,32 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
       return <></>;
   }
 };
+
+export const FILTER_OPTIONS = [
+  {
+    value: FilterTypeEnum.PEAK,
+    display: <FilterTypeIcon type={FilterTypeEnum.PEAK} />,
+  },
+  {
+    value: FilterTypeEnum.LP,
+    display: <FilterTypeIcon type={FilterTypeEnum.LP} />,
+  },
+  {
+    value: FilterTypeEnum.HP,
+    display: <FilterTypeIcon type={FilterTypeEnum.HP} />,
+  },
+  {
+    value: FilterTypeEnum.LS,
+    display: <FilterTypeIcon type={FilterTypeEnum.LS} />,
+  },
+  {
+    value: FilterTypeEnum.HS,
+    display: <FilterTypeIcon type={FilterTypeEnum.HS} />,
+  },
+  {
+    value: FilterTypeEnum.NO,
+    display: <FilterTypeIcon type={FilterTypeEnum.NO} />,
+  },
+];
 
 export default FilterTypeIcon;

--- a/src/renderer/icons/FilterTypeIcon.tsx
+++ b/src/renderer/icons/FilterTypeIcon.tsx
@@ -112,26 +112,32 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
 export const FILTER_OPTIONS = [
   {
     value: FilterTypeEnum.PEAK,
+    label: 'Peak Filter',
     display: <FilterTypeIcon type={FilterTypeEnum.PEAK} />,
   },
   {
     value: FilterTypeEnum.LP,
+    label: 'Low Pass Filter',
     display: <FilterTypeIcon type={FilterTypeEnum.LP} />,
   },
   {
     value: FilterTypeEnum.HP,
+    label: 'High Pass Filter',
     display: <FilterTypeIcon type={FilterTypeEnum.HP} />,
   },
   {
     value: FilterTypeEnum.LS,
+    label: 'Low Shelf Filter',
     display: <FilterTypeIcon type={FilterTypeEnum.LS} />,
   },
   {
     value: FilterTypeEnum.HS,
+    label: 'High Shelf Filter',
     display: <FilterTypeIcon type={FilterTypeEnum.HS} />,
   },
   {
     value: FilterTypeEnum.NO,
+    label: 'Notch Filter',
     display: <FilterTypeIcon type={FilterTypeEnum.NO} />,
   },
 ];

--- a/src/renderer/icons/FilterTypeIcon.tsx
+++ b/src/renderer/icons/FilterTypeIcon.tsx
@@ -1,0 +1,46 @@
+import { FilterTypeEnum } from 'common/constants';
+
+const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
+  switch (type) {
+    case FilterTypeEnum.PEAK:
+      return (
+        <svg
+          width="32"
+          height="16"
+          viewBox="0 0 32 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <line y1="11" x2="31.9991" y2="11" stroke="white" strokeWidth="2" />
+          <path
+            d="M0 14C0 14 5.77285 14 8.64969 14C11.5265 14 13.4444 2 15.9377 2C18.4309 2 20.3488 14 23.6092 14C26.8696 14 32 14 32 14"
+            stroke="#4F6EF7"
+            strokeWidth="2"
+          />
+          <line x1="1" x2="1" y2="16" stroke="white" strokeWidth="2" />
+        </svg>
+      );
+    case FilterTypeEnum.NO:
+      return (
+        <svg
+          width="32"
+          height="16"
+          viewBox="0 0 32 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <line y1="11" x2="31.9991" y2="11" stroke="white" strokeWidth="2" />
+          <path
+            d="M32 2C32 2 26.2271 2 23.3503 2C20.4735 2 18.5556 14 16.0623 14C13.5691 14 11.6512 2 8.39077 2C5.13036 2 5.96046e-07 2 5.96046e-07 2"
+            stroke="#F74FC2"
+            strokeWidth="2"
+          />
+          <line x1="1" x2="1" y2="16" stroke="white" strokeWidth="2" />
+        </svg>
+      );
+    default:
+      return <></>;
+  }
+};
+
+export default FilterTypeIcon;

--- a/src/renderer/icons/FilterTypeIcon.tsx
+++ b/src/renderer/icons/FilterTypeIcon.tsx
@@ -11,13 +11,75 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <line y1="11" x2="31.9991" y2="11" stroke="white" strokeWidth="2" />
           <path
             d="M0 14C0 14 5.77285 14 8.64969 14C11.5265 14 13.4444 2 15.9377 2C18.4309 2 20.3488 14 23.6092 14C26.8696 14 32 14 32 14"
             stroke="#4F6EF7"
             strokeWidth="2"
           />
-          <line x1="1" x2="1" y2="16" stroke="white" strokeWidth="2" />
+        </svg>
+      );
+    case FilterTypeEnum.LP:
+      return (
+        <svg
+          width="32"
+          height="17"
+          viewBox="0 0 32 17"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1 2C1 2 10.5 2 13.5 2C16.5 2 20.5 7.50024 22 10.0002C23.5 12.5002 24.5 15.5002 24.5 16.0002"
+            stroke="#F7844F"
+            strokeWidth="2"
+          />
+        </svg>
+      );
+    case FilterTypeEnum.HP:
+      return (
+        <svg
+          width="32"
+          height="17"
+          viewBox="0 0 32 17"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M32 2C32 2 22.5 2 19.5 2C16.5 2 12.5 7.50024 11 10.0002C9.5 12.5002 8.5 15.5002 8.5 16.0002"
+            stroke="#4FF7D8"
+            strokeWidth="2"
+          />
+        </svg>
+      );
+    case FilterTypeEnum.LS:
+      return (
+        <svg
+          width="32"
+          height="16"
+          viewBox="0 0 32 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1 2.00002C1 2.00002 4.39077 1.99996 8 2C11.6092 2.00004 16.2396 14 19.5 14C22.7604 14 32 14 32 14"
+            stroke="#F74FC2"
+            strokeWidth="2"
+          />
+        </svg>
+      );
+    case FilterTypeEnum.HS:
+      return (
+        <svg
+          width="32"
+          height="16"
+          viewBox="0 0 32 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M32 2.00002C32 2.00002 28.6092 1.99996 25 2C21.3908 2.00004 16.7604 14 13.5 14C10.2396 14 1 14 1 14"
+            stroke="#844FF7"
+            strokeWidth="2"
+          />
         </svg>
       );
     case FilterTypeEnum.NO:
@@ -29,13 +91,11 @@ const FilterTypeIcon = ({ type }: { type: FilterTypeEnum }) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <line y1="11" x2="31.9991" y2="11" stroke="white" strokeWidth="2" />
           <path
-            d="M32 2C32 2 26.2271 2 23.3503 2C20.4735 2 18.5556 14 16.0623 14C13.5691 14 11.6512 2 8.39077 2C5.13036 2 5.96046e-07 2 5.96046e-07 2"
-            stroke="#F74FC2"
+            d="M32 2C32 2 26.2271 2 23.3503 2C20.4735 2 18.5556 14 16.0623 14C13.5691 14 11.6512 2 8.39077 2C5.13036 2 0 2 0 2"
+            stroke="#F74F6E"
             strokeWidth="2"
           />
-          <line x1="1" x2="1" y2="16" stroke="white" strokeWidth="2" />
         </svg>
       );
     default:

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -40,3 +40,25 @@ body {
   justify-content: center;
   text-align: center;
 }
+
+/* width */
+::-webkit-scrollbar {
+  width: 4px;
+}
+
+/* Track */
+::-webkit-scrollbar-track {
+  border-radius: 8px;
+  background: $primary-lighter;
+}
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+  border-radius: 8px;
+  background: $primary-light;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: $primary-default;
+}

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -12,6 +12,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
+  margin: 0px;
 
   #root {
     height: 100%;
@@ -41,24 +42,23 @@ body {
   text-align: center;
 }
 
-/* width */
+/** Scrollbar styles */
 ::-webkit-scrollbar {
-  width: 4px;
+  height: 8px;
 }
 
-/* Track */
+// Scrollbar track
 ::-webkit-scrollbar-track {
   border-radius: 8px;
   background: $primary-lighter;
 }
 
-/* Handle */
+// Scrollbar handle
 ::-webkit-scrollbar-thumb {
   border-radius: 8px;
   background: $primary-light;
-}
 
-/* Handle on hover */
-::-webkit-scrollbar-thumb:hover {
-  background: $primary-default;
+  &:hover {
+    background: $primary-default;
+  }
 }

--- a/src/renderer/styles/Dropdown.scss
+++ b/src/renderer/styles/Dropdown.scss
@@ -88,7 +88,7 @@
       align-content: center;
       font-size: small;
 
-      &:hover,
+      &:focus,
       &:focus-visible {
         background: $secondary-darker;
         outline: none;

--- a/src/renderer/styles/Dropdown.scss
+++ b/src/renderer/styles/Dropdown.scss
@@ -2,32 +2,6 @@
 @import 'spacing';
 
 .dropdown {
-  select {
-    background: $primary-dark;
-    color: $white;
-    border: solid 2px $secondary-default;
-    border-radius: 4px;
-    padding: $spacing-xs;
-
-    option {
-      padding: 2px;
-
-      &:selected {
-        background: $secondary-dark;
-        color: $white;
-      }
-    }
-
-    &:focus-visible {
-      outline: 2px solid $white;
-    }
-
-    &:disabled {
-      background: $primary-light;
-      cursor: default;
-    }
-  }
-
   [role='menu'] {
     background: $primary-dark;
     color: $white;
@@ -45,22 +19,35 @@
       outline: 2px solid $white;
     }
 
-    &:disabled {
-      background: $primary-light;
+    &[aria-disabled='true'] {
+      border: 2px solid $primary-lighter;
+      color: $primary-lighter;
       cursor: default;
+
+      svg {
+        path {
+          stroke: $primary-lighter;
+        }
+
+        &.arrow {
+          path {
+            fill: $primary-lighter;
+          }
+        }
+      }
     }
 
     svg {
       width: 36px;
       height: auto;
-    }
 
-    svg.arrow {
-      width: 12px;
-      height: auto;
-      margin-left: 4px;
-      path {
-        fill: $white;
+      &.arrow {
+        width: 12px;
+        height: auto;
+        margin-left: 4px;
+        path {
+          fill: $white;
+        }
       }
     }
   }

--- a/src/renderer/styles/Dropdown.scss
+++ b/src/renderer/styles/Dropdown.scss
@@ -1,0 +1,103 @@
+@import 'color';
+@import 'spacing';
+
+.dropdown {
+  select {
+    background: $primary-dark;
+    color: $white;
+    border: solid 2px $secondary-default;
+    border-radius: 4px;
+    padding: $spacing-xs;
+
+    option {
+      padding: 2px;
+
+      &:selected {
+        background: $secondary-dark;
+        color: $white;
+      }
+    }
+
+    &:focus-visible {
+      outline: 2px solid $white;
+    }
+
+    &:disabled {
+      background: $primary-light;
+      cursor: default;
+    }
+  }
+
+  [role='menu'] {
+    background: $primary-dark;
+    color: $white;
+    border: solid 2px $secondary-default;
+    border-radius: 4px;
+    padding: $spacing-xs;
+    font-size: small;
+    width: 52px;
+    height: 18px;
+    justify-content: space-between;
+    align-content: center;
+    align-items: center;
+
+    &:focus-visible {
+      outline: 2px solid $white;
+    }
+
+    &:disabled {
+      background: $primary-light;
+      cursor: default;
+    }
+
+    svg {
+      width: 36px;
+      height: auto;
+    }
+
+    svg.arrow {
+      width: 12px;
+      height: auto;
+      margin-left: 4px;
+      path {
+        fill: $white;
+      }
+    }
+  }
+
+  ul {
+    // Position the drop down menu
+    position: absolute;
+    margin-block-start: -4px;
+
+    // Remove default styles
+    list-style-type: none;
+    padding-inline-start: 0px;
+
+    // Apply custom styles
+    background: $primary-dark;
+    color: $white;
+    border: solid 2px $secondary-default;
+    border-radius: 4px;
+    width: 60px;
+    text-align: start;
+    z-index: 1;
+
+    li {
+      padding: $spacing-xs;
+      align-content: center;
+      font-size: small;
+
+      &:hover,
+      &:focus-visible {
+        background: $secondary-darker;
+        outline: none;
+      }
+
+      svg {
+        width: 36px;
+        height: auto;
+      }
+    }
+  }
+}

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -1,18 +1,22 @@
 @import './constant';
 @import './spacing';
 
-$band-height: 344px;
+$band-height: 382px;
 $band-width: 64px;
 
 .mainContent {
   height: 100%;
   width: $content-width;
-  justify-content: space-evenly;
+  display: grid;
+  grid-template-columns: 128px 1fr 48px;
+  grid-template-rows: 100%;
+  gap: $spacing-s;
+  justify-items: center;
 
   .bandLabel {
     height: $band-height;
     justify-content: flex-start;
-    gap: 8px;
+    gap: $spacing-s;
 
     div {
       justify-content: space-around;
@@ -24,6 +28,20 @@ $band-width: 64px;
     }
   }
 
+  .bands {
+    justify-content: space-between;
+    width: 100%;
+    height: 100%;
+    gap: $spacing-s;
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    &::before,
+    &::after {
+      content: ' '; /* Insert space before the first item and after the last one */
+    }
+  }
+
   .band {
     height: $band-height;
     width: $band-width;
@@ -32,11 +50,7 @@ $band-width: 64px;
 
   .sliderButtons {
     height: $band-height;
-    padding-top: 90px;
-    div {
-      margin-top: $spacing-xs;
-      margin-bottom: $spacing-xs;
-    }
+    gap: $spacing-xs;
 
     .sliderButton {
       height: 100px;

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { RefObject, useEffect, useMemo, useRef } from 'react';
 
 export const clamp = (num: number, min: number, max: number) => {
   return Math.min(Math.max(num, min), max);
@@ -39,4 +39,26 @@ export const useThrottle = <Type>(
     lastCalled.current = now;
     fn(arg);
   };
+};
+
+// https://github.com/teetotum/react-attached-properties/blob/master/examples/useClickOutside.js
+export const useClickOutside = <T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T>,
+  callback: () => void
+) => {
+  const handleClick = useMemo(() => {
+    return (e: globalThis.MouseEvent) => {
+      if (!ref.current || ref.current.contains(e.target as Node)) {
+        return;
+      }
+
+      callback();
+    };
+  }, [callback, ref]);
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick, true);
+
+    return () => document.removeEventListener('click', handleClick, true);
+  }, [handleClick]);
 };

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -62,3 +62,24 @@ export const useClickOutside = <T extends HTMLElement = HTMLElement>(
     return () => document.removeEventListener('click', handleClick, true);
   }, [handleClick]);
 };
+
+export const useFocusOutside = <T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T>,
+  callback: () => void
+) => {
+  const handleFocus = useMemo(() => {
+    return (e: globalThis.FocusEvent) => {
+      if (!ref.current || ref.current.contains(e.target as Node)) {
+        return;
+      }
+
+      callback();
+    };
+  }, [callback, ref]);
+
+  useEffect(() => {
+    document.addEventListener('focusin', handleFocus, true);
+
+    return () => document.removeEventListener('focusin', handleFocus, true);
+  }, [handleFocus]);
+};


### PR DESCRIPTION
Goal: Allow the user to select the filter type associated with each of the frequency bands

### Changes
- Add a new `Dropdown` component 
  - Add keyboard arrow functionality for selecting items in the dropdown
- Add a new `FilterTypeIcon` component that renders the filter icon
- Add util functions for determining when a user focused / clicked on an outside element
- Add handlers in the `main` function for getting and setting the filter type