### PR TITLE
JAT-72 Reformat UI layout to match new mockup

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -393,8 +393,10 @@ const createMainWindow = async () => {
     show: false,
     width: 1024,
     minWidth: 1024,
+    maxWidth: 1024,
     height: 512,
     minHeight: 512,
+    maxHeight: 512,
     icon: getAssetPath('icon.png'),
     webPreferences: {
       preload: app.isPackaged

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -393,13 +393,19 @@ const createMainWindow = async () => {
     show: false,
     width: 1024,
     minWidth: 1024,
-    height: 728,
-    minHeight: 728,
+    height: 512,
+    minHeight: 512,
     icon: getAssetPath('icon.png'),
     webPreferences: {
       preload: app.isPackaged
         ? path.join(__dirname, 'preload.js')
         : path.join(__dirname, '../../.erb/dll/preload.js'),
+    },
+    titleBarStyle: 'hidden',
+    titleBarOverlay: {
+      color: '#1c313a',
+      symbolColor: '#ffffff',
+      height: 28,
     },
   });
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,10 +10,13 @@ import SideBar from './SideBar';
 
 const AppContent = () => {
   return (
-    <div className="parameteric-wrapper row">
-      <SideBar />
-      <MainContent />
-    </div>
+    <>
+      <div className="parameteric-wrapper row">
+        <SideBar />
+        <MainContent />
+      </div>
+      {/* <div className="graph-wrapper" /> */}
+    </>
   );
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,7 +10,7 @@ import SideBar from './SideBar';
 
 const AppContent = () => {
   return (
-    <div className="full row">
+    <div className="parameteric-wrapper row">
       <SideBar />
       <MainContent />
     </div>

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -9,6 +9,9 @@
     <title>AQUA</title>
   </head>
   <body>
+    <header class="titlebar row">
+      <span>AQUA</span>
+    </header>
     <div id="root"></div>
   </body>
 </html>

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -21,6 +21,11 @@ body {
     padding-top: $spacing-s;
     height: calc(100vh - $titlebar-height - $spacing-m - $spacing-s);
     width: calc(100vw - 2 * $spacing-m);
+
+    // Add flex so we can split space bweteen parametric and graph views
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-s;
   }
 }
 
@@ -42,8 +47,14 @@ body {
 }
 
 .parameteric-wrapper {
-  height: 100%;
+  flex: 1;
   gap: $spacing-s;
+}
+
+.graph-wrapper {
+  flex: 1;
+  border-radius: $spacing-m;
+  border: 2px solid $secondary-default;
 }
 
 .row {

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -1,23 +1,49 @@
-@import './color';
-@import './spacing';
+@import 'color';
+@import 'constant';
+@import 'spacing';
 
 body {
   position: relative;
   color: white;
-  height: 100vh;
   background: $primary-dark;
   font-family: sans-serif;
   font-size: 1em;
   overflow-y: hidden;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   margin: 0px;
 
   #root {
-    height: 100%;
-    width: 100%;
+    // Spacing and height
+    padding: $spacing-m;
+    padding-top: $spacing-s;
+    height: calc(100vh - $titlebar-height - $spacing-m - $spacing-s);
+    width: calc(100vw - 2 * $spacing-m);
   }
+}
+
+.titlebar {
+  background-color: $primary-dark;
+  height: $titlebar-height;
+  width: 100%;
+  -webkit-app-region: drag; /* Allow user to drag the window using this titlebar */
+  -webkit-user-select: none; /* Prevent user from selecting things */
+  user-select: none;
+
+  span {
+    height: 100%;
+    display: flex;
+    margin-left: $spacing-m;
+    justify-content: end;
+    flex-direction: column;
+  }
+}
+
+.parameteric-wrapper {
+  height: 100%;
+  gap: $spacing-s;
 }
 
 .row {

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -14,7 +14,7 @@ $band-width: 64px;
   padding: $spacing-s;
   justify-items: center;
 
-  border-radius: 16px;
+  border-radius: $spacing-m;
   border: 2px solid $secondary-default;
 
   .bandLabel {

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -1,17 +1,21 @@
-@import './constant';
-@import './spacing';
+@import 'color';
+@import 'constant';
+@import 'spacing';
 
-$band-height: 382px;
+$band-height: 398px;
 $band-width: 64px;
 
 .mainContent {
-  height: 100%;
   width: $content-width;
   display: grid;
   grid-template-columns: 128px 1fr 48px;
   grid-template-rows: 100%;
   gap: $spacing-s;
+  padding: $spacing-s;
   justify-items: center;
+
+  border-radius: 16px;
+  border: 2px solid $secondary-default;
 
   .bandLabel {
     height: $band-height;
@@ -26,26 +30,32 @@ $band-width: 64px;
     .rowLabel {
       margin: $spacing-s 0;
     }
+
+    &::before,
+    &::after {
+      // Insert space above and below band so scrollbar has padding
+      content: ' ';
+    }
   }
 
   .bands {
     justify-content: space-between;
     width: 100%;
-    height: 100%;
     gap: $spacing-s;
     overflow-x: auto;
     overflow-y: hidden;
 
-    &::before,
-    &::after {
-      content: ' '; /* Insert space before the first item and after the last one */
-    }
-  }
+    .band {
+      height: $band-height;
+      width: $band-width;
+      gap: $spacing-s;
 
-  .band {
-    height: $band-height;
-    width: $band-width;
-    gap: $spacing-s;
+      &::before,
+      &::after {
+        // Insert space above and below band so scrollbar has padding
+        content: ' ';
+      }
+    }
   }
 
   .sliderButtons {

--- a/src/renderer/styles/SideBar.scss
+++ b/src/renderer/styles/SideBar.scss
@@ -3,9 +3,10 @@
 @import 'spacing';
 
 .sideBar {
-  height: 100%;
   width: calc(100% - $content-width);
   gap: $spacing-m;
   padding: $spacing-s;
-  border-right: 2px solid $white;
+
+  border-radius: 16px;
+  background: $primary-default;
 }

--- a/src/renderer/styles/SideBar.scss
+++ b/src/renderer/styles/SideBar.scss
@@ -4,9 +4,8 @@
 
 .sideBar {
   width: calc(100% - $content-width);
-  gap: $spacing-m;
   padding: $spacing-s;
 
-  border-radius: 16px;
+  border-radius: $spacing-m;
   background: $primary-default;
 }

--- a/src/renderer/styles/_constant.scss
+++ b/src/renderer/styles/_constant.scss
@@ -1,1 +1,2 @@
-$content-width: 90%;
+$content-width: 88%;
+$titlebar-height: 28px;


### PR DESCRIPTION
### Unsolved / TODO
Can't figure out why using a custom `titleBarOverlay` seems to be triggering this warning
![image](https://user-images.githubusercontent.com/30204513/178803670-2b207eb9-92f6-4bb0-824b-66f1bd9ca314.png)
